### PR TITLE
Fix thread-safe GUI update

### DIFF
--- a/wiki_gui.py
+++ b/wiki_gui.py
@@ -133,14 +133,18 @@ def on_fetch():
     btn_fetch.config(state='disabled')
     status_label.config(text='⏳ 处理中…')
 
+    def update_status(status: str):
+        """在主线程更新GUI状态"""
+        status_label.config(text=status)
+        btn_fetch.config(state='normal')
+
     def task():
         try:
             out = run_export(entry, mode_var.get(), lang_var.get())
             status = f'✅ 成功：{out}'
         except Exception as e:
             status = f'❌ 错误：{e}'
-        status_label.config(text=status)
-        btn_fetch.config(state='normal')
+        root.after(0, lambda: update_status(status))
 
     threading.Thread(target=task, daemon=True).start()
 


### PR DESCRIPTION
## Summary
- update GUI from main thread in `on_fetch`

## Testing
- `python -m py_compile wiki_gui.py`
- `(fails: ModuleNotFoundError: No module named 'wikipedia')` when attempting to import module

------
https://chatgpt.com/codex/tasks/task_e_683fb8f0b7248332bd7248c53ef75cef